### PR TITLE
Add permission for READ_WALLPAPER_INTERNAL

### DIFF
--- a/privapp_whitelist_com.android.wallpaper.xml
+++ b/privapp_whitelist_com.android.wallpaper.xml
@@ -21,5 +21,6 @@
         <permission name="android.permission.MODIFY_DAY_NIGHT_MODE"/>
         <permission name="android.permission.SET_WALLPAPER_COMPONENT"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
+        <permission name="android.permission.READ_WALLPAPER_INTERNAL"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
- Currently having following issue causing bootloop: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions allowlist: {com.android.wallpaper (/system_ext/priv-app/StatixThemePicker): android.permission.READ_WALLPAPER_INTERNAL}